### PR TITLE
feat(kos): domain-separate KOS instances by instance_id

### DIFF
--- a/crates/ot-core/src/kos.rs
+++ b/crates/ot-core/src/kos.rs
@@ -173,8 +173,8 @@ mod tests {
     ) {
         let count = 128;
 
-        let sender = Sender::new(SenderConfig::default(), delta);
-        let receiver = Receiver::new(ReceiverConfig::default());
+        let sender = Sender::new(SenderConfig::default(), delta, Block::ZERO);
+        let receiver = Receiver::new(ReceiverConfig::default(), Block::ZERO);
 
         let mut sender = sender.setup(sender_seeds);
         let mut receiver = receiver.setup(receiver_seeds);
@@ -226,8 +226,8 @@ mod tests {
 
         let count = sender_config.batch_size() * 3;
 
-        let sender = Sender::new(sender_config, delta);
-        let receiver = Receiver::new(receiver_config);
+        let sender = Sender::new(sender_config, delta, Block::ZERO);
+        let receiver = Receiver::new(receiver_config, Block::ZERO);
 
         let mut sender = sender.setup(sender_seeds);
         let mut receiver = receiver.setup(receiver_seeds);
@@ -276,8 +276,8 @@ mod tests {
     ) {
         let count = 128;
 
-        let sender = Sender::new(SenderConfig::default(), delta);
-        let receiver = Receiver::new(ReceiverConfig::default());
+        let sender = Sender::new(SenderConfig::default(), delta, Block::ZERO);
+        let receiver = Receiver::new(ReceiverConfig::default(), Block::ZERO);
 
         let mut sender = sender.setup(sender_seeds);
         let mut receiver = receiver.setup(receiver_seeds);
@@ -308,8 +308,8 @@ mod tests {
     ) {
         let count = 128;
 
-        let sender = Sender::new(SenderConfig::default(), delta);
-        let receiver = Receiver::new(ReceiverConfig::default());
+        let sender = Sender::new(SenderConfig::default(), delta, Block::ZERO);
+        let receiver = Receiver::new(ReceiverConfig::default(), Block::ZERO);
 
         let mut sender = sender.setup(sender_seeds);
         let mut receiver = receiver.setup(receiver_seeds);
@@ -340,8 +340,8 @@ mod tests {
     ) {
         let count = 128;
 
-        let sender = Sender::new(SenderConfig::default(), delta);
-        let receiver = Receiver::new(ReceiverConfig::default());
+        let sender = Sender::new(SenderConfig::default(), delta, Block::ZERO);
+        let receiver = Receiver::new(ReceiverConfig::default(), Block::ZERO);
 
         let mut sender = sender.setup(sender_seeds);
         let mut receiver = receiver.setup(receiver_seeds);

--- a/crates/ot-core/src/kos/receiver.rs
+++ b/crates/ot-core/src/kos/receiver.rs
@@ -29,6 +29,9 @@ pub struct Receiver<T: state::State = state::Initialized> {
     alloc: usize,
     transfer_id: TransferId,
     queue: VecDeque<Queued>,
+    /// Per-instance domain separator mixed into the setup PRG seeds. Must match
+    /// the paired sender's `instance_id`.
+    instance_id: Block,
     state: T,
 }
 
@@ -48,7 +51,9 @@ impl Receiver {
     /// # Arguments
     ///
     /// * `config` - The Receiver's configuration
-    pub fn new(config: ReceiverConfig) -> Self {
+    /// * `instance_id` - Per-instance domain separator. Must match the paired
+    ///   sender's `instance_id`.
+    pub fn new(config: ReceiverConfig, instance_id: Block) -> Self {
         Receiver {
             config,
             // We need to extend SSP OTs for the consistency check.
@@ -57,6 +62,7 @@ impl Receiver {
             alloc: SSP,
             transfer_id: TransferId::default(),
             queue: VecDeque::default(),
+            instance_id,
             state: state::Initialized {},
         }
     }
@@ -67,15 +73,19 @@ impl Receiver {
     ///
     /// * `seeds` - The receiver's rng seeds
     pub fn setup(self, seeds: [[Block; 2]; CSP]) -> Receiver<state::Extension> {
+        let instance_id = self.instance_id;
         Receiver {
             config: self.config,
             alloc: self.alloc,
             transfer_id: self.transfer_id,
             queue: self.queue,
+            instance_id,
             state: state::Extension {
+                // Domain-separate the base-OT-derived PRG seeds by the instance
+                // id, matching the sender's transform.
                 rngs: seeds
                     .into_iter()
-                    .map(|seeds| seeds.map(Prg::from_seed))
+                    .map(|seeds| seeds.map(|seed| Prg::from_seed(seed ^ instance_id)))
                     .collect(),
                 msgs: Vec::default(),
                 choices: Vec::default(),

--- a/crates/ot-core/src/kos/receiver.rs
+++ b/crates/ot-core/src/kos/receiver.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use itybity::{BitLength, FromBitIterator, IntoBitIterator, IntoBits};
 use mpz_common::future::{MaybeDone, Sender, new_output};
-use mpz_core::{Block, prg::Prg};
+use mpz_core::{Block, aes::FIXED_KEY_AES, prg::Prg};
 
 use rand::{Rng as _, SeedableRng};
 use rand_core::RngCore;
@@ -29,6 +29,7 @@ pub struct Receiver<T: state::State = state::Initialized> {
     alloc: usize,
     transfer_id: TransferId,
     queue: VecDeque<Queued>,
+    instance_id: Block,
     state: T,
 }
 
@@ -48,7 +49,8 @@ impl Receiver {
     /// # Arguments
     ///
     /// * `config` - The Receiver's configuration
-    pub fn new(config: ReceiverConfig) -> Self {
+    /// * `instance_id` - Domain separator; must match the paired sender.
+    pub fn new(config: ReceiverConfig, instance_id: Block) -> Self {
         Receiver {
             config,
             // We need to extend SSP OTs for the consistency check.
@@ -57,6 +59,7 @@ impl Receiver {
             alloc: SSP,
             transfer_id: TransferId::default(),
             queue: VecDeque::default(),
+            instance_id,
             state: state::Initialized {},
         }
     }
@@ -67,15 +70,19 @@ impl Receiver {
     ///
     /// * `seeds` - The receiver's rng seeds
     pub fn setup(self, seeds: [[Block; 2]; CSP]) -> Receiver<state::Extension> {
+        let instance_id = self.instance_id;
         Receiver {
             config: self.config,
             alloc: self.alloc,
             transfer_id: self.transfer_id,
             queue: self.queue,
+            instance_id,
             state: state::Extension {
                 rngs: seeds
                     .into_iter()
-                    .map(|seeds| seeds.map(Prg::from_seed))
+                    .map(|seeds| {
+                        seeds.map(|seed| Prg::from_seed(FIXED_KEY_AES.tccr(instance_id, seed)))
+                    })
                     .collect(),
                 msgs: Vec::default(),
                 choices: Vec::default(),

--- a/crates/ot-core/src/kos/sender.rs
+++ b/crates/ot-core/src/kos/sender.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use itybity::ToBits;
 use mpz_common::future::{MaybeDone, Sender as OutputSender, new_output};
-use mpz_core::{Block, prg::Prg};
+use mpz_core::{Block, aes::FIXED_KEY_AES, prg::Prg};
 
 use rand::{Rng as _, SeedableRng, rng};
 
@@ -35,6 +35,7 @@ pub struct Sender<T: state::State = state::Initialized> {
     queue: VecDeque<Queued>,
     transfer_id: TransferId,
     delta: Block,
+    instance_id: Block,
     state: T,
 }
 
@@ -55,7 +56,9 @@ impl Sender<state::Initialized> {
     ///
     /// * `config` - Sender's configuration.
     /// * `delta` - Global COT correlation.
-    pub fn new(config: SenderConfig, delta: Block) -> Self {
+    /// * `instance_id` - Domain separator; must match the paired receiver and
+    ///   differ across instances that reuse `delta`.
+    pub fn new(config: SenderConfig, delta: Block, instance_id: Block) -> Self {
         Sender {
             config,
             // We need to extend SSP OTs for the consistency check.
@@ -65,6 +68,7 @@ impl Sender<state::Initialized> {
             transfer_id: TransferId::default(),
             queue: VecDeque::default(),
             delta,
+            instance_id,
             state: state::Initialized::default(),
         }
     }
@@ -75,14 +79,19 @@ impl Sender<state::Initialized> {
     ///
     /// * `seeds` - The rng seeds chosen during base OT
     pub fn setup(self, seeds: [Block; CSP]) -> Sender<state::Extension> {
+        let instance_id = self.instance_id;
         Sender {
             config: self.config,
             alloc: self.alloc,
             transfer_id: self.transfer_id,
             queue: self.queue,
             delta: self.delta,
+            instance_id,
             state: state::Extension {
-                rngs: seeds.into_iter().map(Prg::from_seed).collect(),
+                rngs: seeds
+                    .into_iter()
+                    .map(|seed| Prg::from_seed(FIXED_KEY_AES.tccr(instance_id, seed)))
+                    .collect(),
                 keys: Vec::default(),
                 extended: false,
                 unchecked_qs_trans: Vec::default(),

--- a/crates/ot-core/src/kos/sender.rs
+++ b/crates/ot-core/src/kos/sender.rs
@@ -35,6 +35,10 @@ pub struct Sender<T: state::State = state::Initialized> {
     queue: VecDeque<Queued>,
     transfer_id: TransferId,
     delta: Block,
+    /// Per-instance domain separator mixed into the setup PRG seeds so that two
+    /// instances sharing the same `delta` and the same base OT produce
+    /// independent extension transcripts.
+    instance_id: Block,
     state: T,
 }
 
@@ -55,7 +59,10 @@ impl Sender<state::Initialized> {
     ///
     /// * `config` - Sender's configuration.
     /// * `delta` - Global COT correlation.
-    pub fn new(config: SenderConfig, delta: Block) -> Self {
+    /// * `instance_id` - Per-instance domain separator. Must match the paired
+    ///   receiver's `instance_id`. Distinct instances that reuse the same
+    ///   `delta` MUST use distinct ids.
+    pub fn new(config: SenderConfig, delta: Block, instance_id: Block) -> Self {
         Sender {
             config,
             // We need to extend SSP OTs for the consistency check.
@@ -65,6 +72,7 @@ impl Sender<state::Initialized> {
             transfer_id: TransferId::default(),
             queue: VecDeque::default(),
             delta,
+            instance_id,
             state: state::Initialized::default(),
         }
     }
@@ -75,14 +83,22 @@ impl Sender<state::Initialized> {
     ///
     /// * `seeds` - The rng seeds chosen during base OT
     pub fn setup(self, seeds: [Block; CSP]) -> Sender<state::Extension> {
+        let instance_id = self.instance_id;
         Sender {
             config: self.config,
             alloc: self.alloc,
             transfer_id: self.transfer_id,
             queue: self.queue,
             delta: self.delta,
+            instance_id,
             state: state::Extension {
-                rngs: seeds.into_iter().map(Prg::from_seed).collect(),
+                // Domain-separate the base-OT-derived PRG seeds by the instance
+                // id. Both parties transform the same chosen seed identically,
+                // so extension correctness is preserved.
+                rngs: seeds
+                    .into_iter()
+                    .map(|seed| Prg::from_seed(seed ^ instance_id))
+                    .collect(),
                 keys: Vec::default(),
                 extended: false,
                 unchecked_qs_trans: Vec::default(),

--- a/crates/ot/src/kos.rs
+++ b/crates/ot/src/kos.rs
@@ -31,8 +31,8 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(0);
         let (base_sender, base_receiver) = ideal_ot();
         let delta = Block::random(&mut rng);
-        let sender = Sender::new(SenderConfig::default(), delta, base_receiver);
-        let receiver = Receiver::new(ReceiverConfig::default(), base_sender);
+        let sender = Sender::new(SenderConfig::default(), delta, Block::ZERO, base_receiver);
+        let receiver = Receiver::new(ReceiverConfig::default(), Block::ZERO, base_sender);
 
         test_rcot(sender, receiver, 128, 1).await;
     }

--- a/crates/ot/src/kos/receiver.rs
+++ b/crates/ot/src/kos/receiver.rs
@@ -40,12 +40,13 @@ impl<BaseOT> Receiver<BaseOT> {
     /// # Arguments
     ///
     /// * `config` - The Receiver's configuration.
+    /// * `instance_id` - Domain separator; must match the paired sender.
     /// * `base_ot` - Base OT.
-    pub fn new(config: ReceiverConfig, base_ot: BaseOT) -> Self {
+    pub fn new(config: ReceiverConfig, instance_id: Block, base_ot: BaseOT) -> Self {
         Self {
             state: State::Initialized {
                 base_ot,
-                receiver: Core::new(config),
+                receiver: Core::new(config, instance_id),
             },
         }
     }

--- a/crates/ot/src/kos/receiver.rs
+++ b/crates/ot/src/kos/receiver.rs
@@ -40,12 +40,14 @@ impl<BaseOT> Receiver<BaseOT> {
     /// # Arguments
     ///
     /// * `config` - The Receiver's configuration.
+    /// * `instance_id` - Per-instance domain separator. Must match the paired
+    ///   sender.
     /// * `base_ot` - Base OT.
-    pub fn new(config: ReceiverConfig, base_ot: BaseOT) -> Self {
+    pub fn new(config: ReceiverConfig, instance_id: Block, base_ot: BaseOT) -> Self {
         Self {
             state: State::Initialized {
                 base_ot,
-                receiver: Core::new(config),
+                receiver: Core::new(config, instance_id),
             },
         }
     }

--- a/crates/ot/src/kos/sender.rs
+++ b/crates/ot/src/kos/sender.rs
@@ -40,12 +40,14 @@ impl<BaseOT> Sender<BaseOT> {
     ///
     /// * `config` - The Sender's configuration.
     /// * `delta` - Global COT correlation.
+    /// * `instance_id` - Domain separator; must match the paired receiver and
+    ///   differ across instances that reuse `delta`.
     /// * `base_ot` - Base OT.
-    pub fn new(config: SenderConfig, delta: Block, base_ot: BaseOT) -> Self {
+    pub fn new(config: SenderConfig, delta: Block, instance_id: Block, base_ot: BaseOT) -> Self {
         Self {
             state: State::Initialized {
                 base_ot,
-                sender: Core::new(config, delta),
+                sender: Core::new(config, delta, instance_id),
             },
         }
     }

--- a/crates/ot/src/kos/sender.rs
+++ b/crates/ot/src/kos/sender.rs
@@ -40,12 +40,15 @@ impl<BaseOT> Sender<BaseOT> {
     ///
     /// * `config` - The Sender's configuration.
     /// * `delta` - Global COT correlation.
+    /// * `instance_id` - Per-instance domain separator. Must match the paired
+    ///   receiver. Distinct KOS instances that reuse the same `delta` MUST use
+    ///   distinct ids.
     /// * `base_ot` - Base OT.
-    pub fn new(config: SenderConfig, delta: Block, base_ot: BaseOT) -> Self {
+    pub fn new(config: SenderConfig, delta: Block, instance_id: Block, base_ot: BaseOT) -> Self {
         Self {
             state: State::Initialized {
                 base_ot,
-                sender: Core::new(config, delta),
+                sender: Core::new(config, delta, instance_id),
             },
         }
     }


### PR DESCRIPTION
Add an `instance_id` domain separator to `kos::Sender`/`Receiver` and mix it into the base-OT-derived PRG seeds (`Prg::from_seed(seed ^ instance_id)`).

This makes two KOS instances that share the same global `delta` and reuse the same base OT produce independent extension transcripts, preventing a malicious receiver from composing per-instance consistency-check leakages to sample or recover `delta`.

API-breaking: `Sender::new`/`Receiver::new` gain an `instance_id: Block`.