### PR TITLE
feat(kos): domain-separate instances with a per-instance salt

### DIFF
--- a/crates/ot-core/src/kos.rs
+++ b/crates/ot-core/src/kos.rs
@@ -173,8 +173,8 @@ mod tests {
     ) {
         let count = 128;
 
-        let sender = Sender::new(SenderConfig::default(), delta);
-        let receiver = Receiver::new(ReceiverConfig::default());
+        let sender = Sender::new(SenderConfig::default(), delta, Block::ZERO);
+        let receiver = Receiver::new(ReceiverConfig::default(), Block::ZERO);
 
         let mut sender = sender.setup(sender_seeds);
         let mut receiver = receiver.setup(receiver_seeds);
@@ -226,8 +226,8 @@ mod tests {
 
         let count = sender_config.batch_size() * 3;
 
-        let sender = Sender::new(sender_config, delta);
-        let receiver = Receiver::new(receiver_config);
+        let sender = Sender::new(sender_config, delta, Block::ZERO);
+        let receiver = Receiver::new(receiver_config, Block::ZERO);
 
         let mut sender = sender.setup(sender_seeds);
         let mut receiver = receiver.setup(receiver_seeds);
@@ -276,8 +276,8 @@ mod tests {
     ) {
         let count = 128;
 
-        let sender = Sender::new(SenderConfig::default(), delta);
-        let receiver = Receiver::new(ReceiverConfig::default());
+        let sender = Sender::new(SenderConfig::default(), delta, Block::ZERO);
+        let receiver = Receiver::new(ReceiverConfig::default(), Block::ZERO);
 
         let mut sender = sender.setup(sender_seeds);
         let mut receiver = receiver.setup(receiver_seeds);
@@ -308,8 +308,8 @@ mod tests {
     ) {
         let count = 128;
 
-        let sender = Sender::new(SenderConfig::default(), delta);
-        let receiver = Receiver::new(ReceiverConfig::default());
+        let sender = Sender::new(SenderConfig::default(), delta, Block::ZERO);
+        let receiver = Receiver::new(ReceiverConfig::default(), Block::ZERO);
 
         let mut sender = sender.setup(sender_seeds);
         let mut receiver = receiver.setup(receiver_seeds);
@@ -340,8 +340,8 @@ mod tests {
     ) {
         let count = 128;
 
-        let sender = Sender::new(SenderConfig::default(), delta);
-        let receiver = Receiver::new(ReceiverConfig::default());
+        let sender = Sender::new(SenderConfig::default(), delta, Block::ZERO);
+        let receiver = Receiver::new(ReceiverConfig::default(), Block::ZERO);
 
         let mut sender = sender.setup(sender_seeds);
         let mut receiver = receiver.setup(receiver_seeds);

--- a/crates/ot-core/src/kos/receiver.rs
+++ b/crates/ot-core/src/kos/receiver.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use itybity::{BitLength, FromBitIterator, IntoBitIterator, IntoBits};
 use mpz_common::future::{MaybeDone, Sender, new_output};
-use mpz_core::{Block, prg::Prg};
+use mpz_core::{Block, aes::FIXED_KEY_AES, prg::Prg};
 
 use rand::{Rng as _, RngExt, SeedableRng};
 
@@ -28,6 +28,7 @@ pub struct Receiver<T: state::State = state::Initialized> {
     alloc: usize,
     transfer_id: TransferId,
     queue: VecDeque<Queued>,
+    instance_id: Block,
     state: T,
 }
 
@@ -47,7 +48,7 @@ impl Receiver {
     /// # Arguments
     ///
     /// * `config` - The Receiver's configuration
-    pub fn new(config: ReceiverConfig) -> Self {
+    pub fn new(config: ReceiverConfig, instance_id: Block) -> Self {
         Receiver {
             config,
             // We need to extend SSP OTs for the consistency check.
@@ -56,6 +57,7 @@ impl Receiver {
             alloc: SSP,
             transfer_id: TransferId::default(),
             queue: VecDeque::default(),
+            instance_id,
             state: state::Initialized {},
         }
     }
@@ -66,15 +68,19 @@ impl Receiver {
     ///
     /// * `seeds` - The receiver's rng seeds
     pub fn setup(self, seeds: [[Block; 2]; CSP]) -> Receiver<state::Extension> {
+        let instance_id = self.instance_id;
         Receiver {
             config: self.config,
             alloc: self.alloc,
             transfer_id: self.transfer_id,
             queue: self.queue,
+            instance_id,
             state: state::Extension {
                 rngs: seeds
                     .into_iter()
-                    .map(|seeds| seeds.map(Prg::from_seed))
+                    .map(|seeds| {
+                        seeds.map(|seed| Prg::from_seed(FIXED_KEY_AES.tccr(instance_id, seed)))
+                    })
                     .collect(),
                 msgs: Vec::default(),
                 choices: Vec::default(),

--- a/crates/ot-core/src/kos/sender.rs
+++ b/crates/ot-core/src/kos/sender.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use itybity::ToBits;
 use mpz_common::future::{MaybeDone, Sender as OutputSender, new_output};
-use mpz_core::{Block, prg::Prg};
+use mpz_core::{Block, aes::FIXED_KEY_AES, prg::Prg};
 
 use rand::{Rng as _, RngExt, SeedableRng, rng};
 
@@ -33,6 +33,7 @@ pub struct Sender<T: state::State = state::Initialized> {
     queue: VecDeque<Queued>,
     transfer_id: TransferId,
     delta: Block,
+    instance_id: Block,
     state: T,
 }
 
@@ -53,7 +54,7 @@ impl Sender<state::Initialized> {
     ///
     /// * `config` - Sender's configuration.
     /// * `delta` - Global COT correlation.
-    pub fn new(config: SenderConfig, delta: Block) -> Self {
+    pub fn new(config: SenderConfig, delta: Block, instance_id: Block) -> Self {
         Sender {
             config,
             // We need to extend SSP OTs for the consistency check.
@@ -63,6 +64,7 @@ impl Sender<state::Initialized> {
             transfer_id: TransferId::default(),
             queue: VecDeque::default(),
             delta,
+            instance_id,
             state: state::Initialized::default(),
         }
     }
@@ -73,14 +75,19 @@ impl Sender<state::Initialized> {
     ///
     /// * `seeds` - The rng seeds chosen during base OT
     pub fn setup(self, seeds: [Block; CSP]) -> Sender<state::Extension> {
+        let instance_id = self.instance_id;
         Sender {
             config: self.config,
             alloc: self.alloc,
             transfer_id: self.transfer_id,
             queue: self.queue,
             delta: self.delta,
+            instance_id,
             state: state::Extension {
-                rngs: seeds.into_iter().map(Prg::from_seed).collect(),
+                rngs: seeds
+                    .into_iter()
+                    .map(|seed| Prg::from_seed(FIXED_KEY_AES.tccr(instance_id, seed)))
+                    .collect(),
                 keys: Vec::default(),
                 extended: false,
                 unchecked_qs_trans: Vec::default(),

--- a/crates/ot/src/kos.rs
+++ b/crates/ot/src/kos.rs
@@ -31,8 +31,8 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(0);
         let (base_sender, base_receiver) = ideal_ot();
         let delta = Block::random(&mut rng);
-        let sender = Sender::new(SenderConfig::default(), delta, base_receiver);
-        let receiver = Receiver::new(ReceiverConfig::default(), base_sender);
+        let sender = Sender::new(SenderConfig::default(), delta, Block::ZERO, base_receiver);
+        let receiver = Receiver::new(ReceiverConfig::default(), Block::ZERO, base_sender);
 
         test_rcot(sender, receiver, 128, 1).await;
     }

--- a/crates/ot/src/kos/receiver.rs
+++ b/crates/ot/src/kos/receiver.rs
@@ -41,11 +41,11 @@ impl<BaseOT> Receiver<BaseOT> {
     ///
     /// * `config` - The Receiver's configuration.
     /// * `base_ot` - Base OT.
-    pub fn new(config: ReceiverConfig, base_ot: BaseOT) -> Self {
+    pub fn new(config: ReceiverConfig, instance_id: Block, base_ot: BaseOT) -> Self {
         Self {
             state: State::Initialized {
                 base_ot,
-                receiver: Core::new(config),
+                receiver: Core::new(config, instance_id),
             },
         }
     }

--- a/crates/ot/src/kos/sender.rs
+++ b/crates/ot/src/kos/sender.rs
@@ -41,11 +41,11 @@ impl<BaseOT> Sender<BaseOT> {
     /// * `config` - The Sender's configuration.
     /// * `delta` - Global COT correlation.
     /// * `base_ot` - Base OT.
-    pub fn new(config: SenderConfig, delta: Block, base_ot: BaseOT) -> Self {
+    pub fn new(config: SenderConfig, delta: Block, instance_id: Block, base_ot: BaseOT) -> Self {
         Self {
             state: State::Initialized {
                 base_ot,
-                sender: Core::new(config, delta),
+                sender: Core::new(config, delta, instance_id),
             },
         }
     }


### PR DESCRIPTION
Adds an `instance_id` to `kos::Sender`/`Receiver`, mixed into each base-OT-derived setup PRG seed via a tweakable correlation-robust hash: `Prg::from_seed(FIXED_KEY_AES.tccr(instance_id, seed))`.

KOS's security is analysed for a single extension instance per `delta`. When several instances share one global `delta` — as in tlsnotary/tlsn#1173, where each RCOT consumer gets its own instance — they fall outside that single-instance assumption, and the implementation does no per-instance domain separation.

### API
Breaking: `Sender::new`/`Receiver::new` gain an `instance_id: Block`. Paired sender and receiver must use the same id; distinct instances reusing one `delta` must use distinct ids. Single-instance callers can pass `Block::ZERO`.